### PR TITLE
Remove srcs from go_library compat rule

### DIFF
--- a/go/compat.build_defs
+++ b/go/compat.build_defs
@@ -10,7 +10,7 @@ def go_library(name:str, srcs:list, asm_srcs:list=None, hdrs:list=None, out:str=
 
     return filegroup(
         name = name,
-        srcs = srcs,
+        #srcs = srcs,
         deps = deps,
         visibility = visibility,
         test_only = test_only,


### PR DESCRIPTION
It seem to make builds much slower
